### PR TITLE
make coverage understand the tox paths

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[paths]
+source = obal/
+  .tox/*/lib/*/site-packages/obal/
+
+[run]
+source = obal/
+parallel = true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include requirements*.txt
 include LICENSE
+include .coveragerc
 recursive-include rules *.py

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,9 @@ commands =
     check-manifest --ignore tox.ini,tests*
     # check -r currently fails
     python setup.py check -m -s
-    flake8 .
+    flake8 setup.py obal tests
     pytest --cov={envsitepackagesdir}/obal {posargs}
+    coverage combine
     - coveralls
 passenv = TRAVIS TRAVIS_*
 


### PR DESCRIPTION
this ensures that the tox paths are merged to the real path and coveralls and co can report the coverage nicely (with highlighting etc)